### PR TITLE
Fix path to BarcodeScannerUI.xaml

### DIFF
--- a/src/wp8/BarcodeScannerTask.cs
+++ b/src/wp8/BarcodeScannerTask.cs
@@ -43,7 +43,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 }
 
                 root.Navigated += this.OnNavigated;
-                root.Navigate(new Uri("/Plugins/phonegap-plugin-barcodescanner/BarcodeScannerUI.xaml", UriKind.Relative));
+                root.Navigate(new Uri("/Plugins/com.phonegap.plugins.barcodescanner/BarcodeScannerUI.xaml", UriKind.Relative));
             });
         }
 


### PR DESCRIPTION
Since we have a different plugin id from the upstream we need to change the path to the BarcodeScannerUI.xaml.

ping @EddyVerbruggen and @nadyaA 
